### PR TITLE
Fix DLSS-NR stuck at build epoch 0 under Proton/DXVK

### DIFF
--- a/OptiScaler/wrapped/wrapped_swapchain.cpp
+++ b/OptiScaler/wrapped/wrapped_swapchain.cpp
@@ -334,6 +334,14 @@ static HRESULT LocalPresent(IDXGISwapChain* pSwapChain, UINT SyncInterval, UINT 
 
         if (presentResult == S_OK)
         {
+            // DXVK returns below before the native path advances the NR epoch.
+            // Count a completed Present; retain the deferred NR evaluation guard.
+            if (willPresent)
+            {
+                _frameCounter++;
+                State::Instance().frameCount = _frameCounter;
+            }
+
             LOG_TRACE("3 {}", (UINT) presentResult);
         }
         else if (presentResult == DXGI_ERROR_DEVICE_REMOVED)


### PR DESCRIPTION
DLSS-NR could be enabled in Bodycam without changing the image. The log stayed at `build epoch 0`, with no `primary feature ready` message.

The DXVK path in `LocalPresent()` returns before updating `State::frameCount`. NR waits for that counter to advance before evaluating the newly created model, so it remains pending.

This change advances the counter after a successful DXVK presentation, excluding `DXGI_PRESENT_TEST`. The existing NR synchronisation guard remains intact.

Tested an equivalent local DLL patch with Bodycam, RTX 4070, Proton and NVIDIA Linux driver **610.57.04**. After the change:

- The epoch advanced and `primary feature ready` appeared.
- The log recorded NR composition and GPU execution timings.
- Toggling NR produced a visible difference.

Validation so far covers this setup. Reports from other Proton games and configurations would help confirm compatibility.
