### PR TITLE
DLSS-NR DeferredDLSS: fix the screen flash from the presented-frame counter

### DIFF
--- a/OptiScaler/shaders/dlssnr/DlssNr_DeferredSr.inl
+++ b/OptiScaler/shaders/dlssnr/DlssNr_DeferredSr.inl
@@ -269,12 +269,24 @@ bool PrepareHalfRate(Generation& g, ID3D12GraphicsCommandList* cmd, NVSDK_NGX_Pa
 void Before(ID3D12GraphicsCommandList* cmd, NVSDK_NGX_Parameter* source,
             unsigned long long epoch, ID3D12CommandQueue* queue, bool privateJob = false)
 {
-    if (pending.cmd && current) current->reset = true; // abandoned/failed main SR call
+    if (pending.cmd && current)
+    {
+        LOG_DEBUG("DLSS-NR deferred: Before entry with a stale pending (previous After never ran) -> reset. epoch {}", epoch);
+        current->reset = true; // abandoned/failed main SR call
+    }
     pending = {};
     struct ResetOnGap
     {
-        ~ResetOnGap() { if (!pending.cmd && current) { current->reset = true; current->hold.Reset(); if (current->half) current->half->Reset(); } }
-    } resetOnGap;
+        unsigned long long epoch;
+        ~ResetOnGap()
+        {
+            if (!pending.cmd && current)
+            {
+                LOG_DEBUG("DLSS-NR deferred: Before returned without arming a seam -> reset + hold/half cleared. epoch {}", epoch);
+                current->reset = true; current->hold.Reset(); if (current->half) current->half->Reset();
+            }
+        }
+    } resetOnGap { epoch };
     Collect();
     const auto& cfg = *Config::Instance();
     if (cfg.DlssNrUseProxy.value_or_default() || cfg.DlssNrHoldFrame.value_or_default() ||
@@ -408,7 +420,8 @@ void Before(ID3D12GraphicsCommandList* cmd, NVSDK_NGX_Parameter* source,
         Say("private DLSS created; waiting for a later submission epoch");
         return;
     }
-    if (epoch == g.createEpoch) return;
+    if (epoch == g.createEpoch)
+    { LOG_DEBUG("DLSS-NR deferred: Before skipped -- epoch {} == createEpoch (feature built this frame)", epoch); return; }
 
     if (g.sampleAndHold)
     {
@@ -499,6 +512,8 @@ void Before(ID3D12GraphicsCommandList* cmd, NVSDK_NGX_Parameter* source,
             p->Set(NVSDK_NGX_Parameter_DLSS_Exposure_Scale, 1.0f);
             p->Set(NVSDK_NGX_Parameter_Sharpness, 0.0f);
             pending = { cmd, source, output, epoch, frame.PreExposure, false, half };
+            LOG_DEBUG("DLSS-NR deferred: Before armed epoch {} half {} preExp {:.4f} reset-carried {}", epoch, half,
+                      frame.PreExposure, frame.Reset);
         }
     }
     else { g.reset = true; Say("waiting for NR evaluation; clean SR frame retained"); }
@@ -547,7 +562,14 @@ void After(ID3D12GraphicsCommandList* cmd, NVSDK_NGX_Parameter* source, unsigned
     // reconstruction pop (the reported screen flash).
     if (!current || current->failed || pair.cmd != cmd || pair.caller != source ||
         pair.output != GetResource(source, NVSDK_NGX_Parameter_Output, "DLSSD.Output"))
-    { if (current) current->reset = true; return; }
+    {
+        LOG_DEBUG("DLSS-NR deferred: After no-op -> reset. current={} failed={} cmdMatch={} callerMatch={} "
+                  "epoch(pending/now)={}/{} outputMatch={}",
+                  current != nullptr, current && current->failed, pair.cmd == cmd, pair.caller == source, pair.epoch,
+                  epoch, pair.output == GetResource(source, NVSDK_NGX_Parameter_Output, "DLSSD.Output"));
+        if (current) current->reset = true;
+        return;
+    }
     auto& g = *current;
     const auto& cfg = *Config::Instance();
     if ((cfg.RestoreComputeSignature.value_or_default() || cfg.RestoreGraphicSignature.value_or_default()) &&
@@ -562,6 +584,11 @@ void After(ID3D12GraphicsCommandList* cmd, NVSDK_NGX_Parameter* source, unsigned
         if (result != NVSDK_NGX_Result_Success)
         { g.failed = true; if (g.half) g.half->Reset(); Say("private DLSS evaluation failed: " + std::to_string((unsigned)result)); return; }
     }
+    if (g.reset)
+        LOG_DEBUG("DLSS-NR deferred: After fed Reset=1 to the private DLSS SR this frame (history restart). "
+                  "epoch {} skipNr {} half {}", epoch, pair.skipNr, pair.half);
+    else
+        LOG_TRACE("DLSS-NR deferred: After applied epoch {} skipNr {} half {}", epoch, pair.skipNr, pair.half);
     g.reset = false;
     Barrier(cmd, g.residualOutput, D3D12_RESOURCE_STATE_UNORDERED_ACCESS, D3D12_RESOURCE_STATE_NON_PIXEL_SHADER_RESOURCE);
     bool half = pair.half && g.half && !g.half->failed;

--- a/OptiScaler/shaders/dlssnr/DlssNr_DeferredSr.inl
+++ b/OptiScaler/shaders/dlssnr/DlssNr_DeferredSr.inl
@@ -362,6 +362,9 @@ void Before(ID3D12GraphicsCommandList* cmd, NVSDK_NGX_Parameter* source,
     else device->Release();
     auto& g = *current;
     if (g.failed) return;
+    // NrSeamEpoch() (DlssNr_Dx12.cpp) advances the epoch on every Before seam even when the
+    // presented-frame counter stalls (a DXGI_PRESENT_TEST between two rendered frames), so this
+    // is only reachable on a genuine second upscale in one NR frame. Skip it; the next runs.
     if (g.began && g.lastBeginEpoch == epoch)
     { g.reset = true; Say("inactive: more than one upscale in a submission epoch"); return; }
     g.began = true;
@@ -508,7 +511,9 @@ bool ResolvePrivate(ID3D12GraphicsCommandList* cmd, NVSDK_NGX_Parameter* source,
                     unsigned long long epoch, ID3D12Resource* destination)
 {
     const auto pair = pending; pending = {};
-    if (!current || current->failed || pair.cmd != cmd || pair.caller != source || pair.epoch != epoch)
+    // No epoch match, as in After() -- see the comment there. (Dead path on this branch: async NR
+    // was removed in v0.7.1 and nothing calls ResolvePrivate; kept consistent for a future revival.)
+    if (!current || current->failed || pair.cmd != cmd || pair.caller != source)
         return false;
     auto& g = *current;
     Use use(g, cmd);
@@ -529,7 +534,18 @@ void After(ID3D12GraphicsCommandList* cmd, NVSDK_NGX_Parameter* source, unsigned
 {
     const auto pair = pending;
     pending = {}; // Consume once, only for the immediately matching successful upscale.
-    if (!current || current->failed || pair.cmd != cmd || pair.caller != source || pair.epoch != epoch ||
+    // Deliberately no epoch match. `epoch` is NrSeamEpoch() (DlssNr_Dx12.cpp), which is monotonic on
+    // the Before seam but on this After seam still just follows the raw presented-frame counter --
+    // and that counter is incremented from the wrapped swapchain's Present handler, on a thread that
+    // runs concurrently with the render thread recording this evaluate. In a pipelined engine it can
+    // tick between this evaluate's Before and After seam (observed +1 one-to-two times a second in
+    // NBA 2K26, Frame Generation OFF -- FG only raises the present rate, it is not required), which
+    // is not a frame boundary. Freshness is already structural: Before() clears `pending` at the top
+    // of every frame and it is consumed once here, so a surviving pending is always this evaluate's.
+    // Identity is the cmd list + parameter block + output resource triple. Gating on the epoch here
+    // only manufactured spurious private-SR history restarts -> temporal reset -> a two-frame
+    // reconstruction pop (the reported screen flash).
+    if (!current || current->failed || pair.cmd != cmd || pair.caller != source ||
         pair.output != GetResource(source, NVSDK_NGX_Parameter_Output, "DLSSD.Output"))
     { if (current) current->reset = true; return; }
     auto& g = *current;

--- a/OptiScaler/shaders/dlssnr/DlssNr_Dx12.cpp
+++ b/OptiScaler/shaders/dlssnr/DlssNr_Dx12.cpp
@@ -433,6 +433,44 @@ void ClearCaptureDirectory()
 
 unsigned long long g_frames = 0;
 
+// The epoch the deferred NR seams key their per-frame bookkeeping on.
+//
+// The obvious source, State::Instance().frameCount, counts *presented* frames: wrapped_swapchain
+// skips its increment on a DXGI_PRESENT_TEST -- an occlusion probe that flip-model games issue
+// between real frames, and that DXGI asks for after DXGI_STATUS_OCCLUDED. When it stalls, two
+// consecutively rendered frames hand DeferredSr::Before the same epoch; the Before guard reads that
+// as a duplicate upscale, resets NR history and skips the contribution for that frame -- a visible
+// flash, alternating with the frames where it does run. (The DX11/Vulkan bridges pass their own
+// submitted-frame counter and do not have this. The in-place NR path below is left on the raw
+// counter -- it does not bracket a private SR and has no history-continuity gate.)
+//
+// So: follow the real epoch whenever it moves, and on a Before seam synthesise a +1 tick when it
+// does not. Strictly monotonic, advances by exactly one per rendered frame in the common case --
+// which is also what the "epoch == last + 1" history-continuity checks want.
+unsigned long long g_nrRawEpoch = ~0ull;
+unsigned long long g_nrSeamEpoch = 0;
+
+unsigned long long NrSeamEpoch(bool beginSeam, ID3D12CommandQueue* timingQueue, unsigned long long submissionEpoch)
+{
+    const unsigned long long raw = timingQueue != nullptr ? submissionEpoch : State::Instance().frameCount;
+
+    if (raw != g_nrRawEpoch)
+    {
+        // Follow a forward jump (real frames genuinely elapsed -- e.g. the menu was open); never
+        // repeat or rewind.
+        g_nrSeamEpoch = raw > g_nrSeamEpoch ? raw : g_nrSeamEpoch + 1;
+        g_nrRawEpoch = raw;
+    }
+    else if (beginSeam)
+    {
+        // Raw epoch stalled between two rendered frames (a test-present) -- synthesise the tick so
+        // the NR seam is not misread as a duplicate.
+        ++g_nrSeamEpoch;
+    }
+
+    return g_nrSeamEpoch;
+}
+
 // A capture requested from outside the game: when the render path has no fence of its own, the write
 // waits until this frame count, by which point the GPU is certainly past the copies.
 unsigned long long g_captureWriteAtFrame = 0;
@@ -2928,7 +2966,7 @@ void EvaluateInternal(ID3D12GraphicsCommandList* cmdList, NVSDK_NGX_Parameter* p
     {
         if (cmdList != nullptr && params != nullptr)
         {
-            const auto epoch = timingQueue != nullptr ? submissionEpoch : State::Instance().frameCount;
+            const auto epoch = NrSeamEpoch(beforeUpscale, timingQueue, submissionEpoch);
             if (beforeUpscale)
                 DeferredSr::Before(cmdList, params, epoch, timingQueue);
             else


### PR DESCRIPTION
## What

Fix for Issue #9 

Fixes an intermittent screen flash on the **DeferredDLSS** path (`DlssNr.Enabled` +
`DlssNr.RunBeforeSR` + `DlssNr.DeferredDLSS`, D3D12): the neural-rendering contribution
drops out and returns with a reconstruction pop ~1–2×/second, camera static,
scene-independent. Reproduced on **NBA 2K26 with DLSS Frame Generation OFF**.

Two commits:

1. **The fix** — behavioural, ~57 lines across `DlssNr_DeferredSr.inl` + `DlssNr_Dx12.cpp`.
2. **Diagnostics** — `LOG_DEBUG`/`LOG_TRACE` on every deferred-seam path that feeds
   `Reset=1` or skips a seam. Purely additive; drop this commit if the log volume at
   `LogLevel=1` is unwanted.

## Root cause

The deferred path keys its per-frame bookkeeping on `State::frameCount`, the
presented-frame counter `wrapped_swapchain` increments from the `Present` handler.
Two independent faults feed the same symptom:

**1. Counter advances mid-evaluate.** `Present` runs on a thread concurrent with the
render thread recording `D3D12_EvaluateFeature`. In a pipelined engine the counter can
tick in the sub-millisecond gap between `DeferredSr::Before` and `DeferredSr::After` —
the two seams bracketing one evaluate. `After()` then sees an epoch one higher than
`Before()` stamped on `pending`, rejects the correct pair via `pair.epoch != epoch`,
forces `current->reset`, and the next frame feeds `Reset=1` to the private DLSS SR →
temporal-history drop → the pop. A `LogLevel=1` capture showed **8 such spurious
restarts in 14 s**, every one with the cmd-list + parameter-block + output-resource
triple all matching and only the epoch off, by exactly +1.

DLSS-G is **not** required — it only raises the present rate, so it fires the race more
often. NBA 2K26 hit it with FG off.

**2. Counter stalls between two rendered frames.** `wrapped_swapchain` skips its
increment on a `DXGI_PRESENT_TEST` (occlusion probe after `DXGI_STATUS_OCCLUDED`). Two
consecutive `Before()` seams then get the same epoch; the
`g.began && g.lastBeginEpoch == epoch` guard reads that as a duplicate upscale, sets
`g.reset` and skips the contribution. Same pop.

## The fix

- **Drop `pair.epoch != epoch`** from `DeferredSr::After()` (and the identical gate in
  `ResolvePrivate()`, for consistency — it is dead code since async NR was removed in
  v0.7.1, but kept aligned). The cmd-list + parameter-block + output-resource triple
  already identifies the matching upscale; freshness is structural, since `Before()`
  clears `pending` at the top of every frame and `After()` consumes it exactly once.

- **New `NrSeamEpoch(beginSeam, timingQueue, submissionEpoch)`** in `DlssNr_Dx12.cpp`.
  Follows the real epoch whenever it moves (forward jumps included) and, on a `Before`
  seam, synthesises a `+1` tick when it has not. Strictly monotonic, advancing by
  exactly one per rendered frame in the common case — which is also what the
  `epoch == last + 1` history-continuity checks want. The single `DeferredSr` epoch
  derivation in `EvaluateInternal` uses it. The in-place NR path
  (`frame.SubmissionEpoch`) is left on the raw counter: it brackets no private SR and
  has no continuity gate. DX11/Vulkan bridges pass their own submitted-frame counter
  and are unaffected.

## Blast radius

Both changes live entirely inside the `DeferredSr` path, gated by
`DlssNrEnabled && DlssNrDeferredDlss` (default-off). For a healthy +1-per-frame counter
`NrSeamEpoch` is an identity passthrough and `After()` saw equal epochs anyway, so
well-behaved games are unchanged — only the already-flashing configurations differ.
The one behaviour *difference* (not identity) is that `NrSeamEpoch` stays monotonic
across a `State::frameCount` reset (e.g. swapchain recreation) instead of doing one
history reset there; the generation-rebuild path resets history anyway.

## Testing

- **In-game:** `LogLevel=1` capture on NBA 2K26, ~2280 deferred frames over ~40 s —
  **zero** spurious `After` no-op resets, **zero** stuck-counter resets, epochs strictly
  `+1`; the only history restarts were the ones NBA 2K26 itself requested
  (`the game asked for a history reset (N so far)`).
- **Build:** clean Release + Debug x64, 0 errors, warning count unchanged from the
  `ec96f42f` baseline. New code is `.clang-format`-clean; the surrounding `.inl` /
  `.cpp` are not formatted to the repo `.clang-format`, so edits were hand-matched to
  each file's local style (running the formatter rewrites the whole file).
- **CONTRIBUTING.md:** no `pch.h` changes, no new globals in `pch.h`.

## Not included

The deeper option — replacing the re-derived epoch with a private per-evaluate
sequence number stamped on `pending` and read back in `After()`. `NrSeamEpoch` + the
`After()`/`ResolvePrivate()` epoch drop is the minimal fix and is what was verified
in-game; the sequence-number refactor can follow if the half-rate / ResidualFg
continuity path wants exact `+1`-per-evaluate semantics.

### Known nit

After dropping the epoch term, `ResolvePrivate`'s `epoch` parameter is unused (the
function itself is dead on v0.7.1 — no callers since async NR removal). Left as-is to
keep the diff minimal and the signature aligned with `After()`; happy to
`[[maybe_unused]]` it or drop `ResolvePrivate` in a follow-up, your call.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
