### PR TITLE
Fix NR bridge exposure pointers and RR placement routing

### DIFF
--- a/OptiScaler/dlssnr/DlssNr_Menu.cpp
+++ b/OptiScaler/dlssnr/DlssNr_Menu.cpp
@@ -159,7 +159,8 @@ void RenderMenu(Config* config, float menuResScale)
             config->DlssNrDeferredDlss = deferredDlss;
         HelpMarker("Compute NR at input resolution, upscale its changes with DLSS, then apply them after SR.\nExperimental: may flicker and adds GPU cost. Requires DLSS on DX12 or its bridges; does not support RR.\nOverrides Apply before Super Resolution. Disable Hold frame, Compare and Debug view.");
         if (deferredDlss && rayReconstruction)
-            ImGui::TextWrapped("Generate before / apply after is unavailable with RR. Apply before Super Resolution controls NR placement.");
+            ImGui::TextWrapped("Generate before / apply after is unavailable with RR. Apply before Super Resolution "
+                               "controls NR placement.");
         else if (deferredDlss)
             ImGui::TextWrapped("Residual DLSS: %s", DlssNr::DeferredDlssStatus().c_str());
         ImGui::BeginDisabled(!deferredDlss || rayReconstruction);

--- a/OptiScaler/dlssnr/DlssNr_Menu.cpp
+++ b/OptiScaler/dlssnr/DlssNr_Menu.cpp
@@ -133,7 +133,9 @@ void RenderMenu(Config* config, float menuResScale)
         HelpMarker("Enhance lighting and material appearance with the NR model. Placement selects before or after upscaling.\nRequires nvngx_dlssnr.dll plus the included nvngx.dll_dlssnr.dll helper.");
 
         bool beforeSr = config->DlssNrRunBeforeSr.value_or_default();
-        const bool deferredActive = config->DlssNrDeferredDlss.value_or_default();
+        const auto activeFeature = State::Instance().currentFeature;
+        const bool rayReconstruction = activeFeature && activeFeature->GetUpscalerType() == Upscaler::DLSSD;
+        const bool deferredActive = config->DlssNrDeferredDlss.value_or_default() && !rayReconstruction;
         if (deferredActive)
             ImGui::BeginDisabled();
         if (ImGui::Checkbox("Apply before Super Resolution", &beforeSr))
@@ -156,9 +158,11 @@ void RenderMenu(Config* config, float menuResScale)
         if (ImGui::Checkbox("Generate before SR, apply after SR (DLSS)", &deferredDlss))
             config->DlssNrDeferredDlss = deferredDlss;
         HelpMarker("Compute NR at input resolution, upscale its changes with DLSS, then apply them after SR.\nExperimental: may flicker and adds GPU cost. Requires DLSS on DX12 or its bridges; does not support RR.\nOverrides Apply before Super Resolution. Disable Hold frame, Compare and Debug view.");
-        if (deferredDlss)
+        if (deferredDlss && rayReconstruction)
+            ImGui::TextWrapped("Generate before / apply after is unavailable with RR. Apply before Super Resolution controls NR placement.");
+        else if (deferredDlss)
             ImGui::TextWrapped("Residual DLSS: %s", DlssNr::DeferredDlssStatus().c_str());
-        ImGui::BeginDisabled(!deferredDlss);
+        ImGui::BeginDisabled(!deferredDlss || rayReconstruction);
         bool residualFg = config->DlssNrResidualFg.value_or_default();
         if (ImGui::Checkbox("NR every second frame (NVIDIA FG, experimental)", &residualFg))
             config->DlssNrResidualFg = residualFg;

--- a/OptiScaler/inputs/NVNGX_DLSS_Dx12.cpp
+++ b/OptiScaler/inputs/NVNGX_DLSS_Dx12.cpp
@@ -1121,8 +1121,7 @@ NVSDK_NGX_API NVSDK_NGX_Result NVSDK_NGX_D3D12_EvaluateFeature(ID3D12GraphicsCom
 
     const auto tracked = HandleToFeature.Read(handleId);
     const auto feature = tracked.feature;
-    bool nrUpscale = feature == NVSDK_NGX_Feature_SuperSampling ||
-                     feature == NVSDK_NGX_Feature_RayReconstruction;
+    bool nrUpscale = feature == NVSDK_NGX_Feature_SuperSampling || feature == NVSDK_NGX_Feature_RayReconstruction;
     bool rayReconstruction = feature == NVSDK_NGX_Feature_RayReconstruction;
     // A live OptiScaler backend is additional evidence, especially if the
     // creation record is absent or an SR handle has switched to DLSSD.
@@ -1179,8 +1178,7 @@ NVSDK_NGX_API NVSDK_NGX_Result NVSDK_NGX_D3D12_EvaluateFeature(ID3D12GraphicsCom
             LOG_DEBUG("Passthrough to native DLSS EvaluateFeature for handle {}", handleId);
 
             if (nrUpscale)
-                DlssNr::EvaluateBeforeUpscale(InCmdList, InParameters, nullptr, 0,
-                                              rayReconstruction);
+                DlssNr::EvaluateBeforeUpscale(InCmdList, InParameters, nullptr, 0, rayReconstruction);
 
             NVSDK_NGX_Result result =
                 NVNGXProxy::D3D12_EvaluateFeature()(InCmdList, InFeatureHandle, InParameters, InCallback);
@@ -1192,8 +1190,7 @@ NVSDK_NGX_API NVSDK_NGX_Result NVSDK_NGX_D3D12_EvaluateFeature(ID3D12GraphicsCom
             // motion vectors too, and its handle can reach here because the branch above does not
             // return, so filtering on the parameter block alone would run the model twice a frame.
             if (result == NVSDK_NGX_Result_Success && nrUpscale)
-                DlssNr::EvaluateAfterUpscale(InCmdList, InParameters, nullptr,
-                                             rayReconstruction);
+                DlssNr::EvaluateAfterUpscale(InCmdList, InParameters, nullptr, rayReconstruction);
 
             return result;
         }
@@ -1216,16 +1213,14 @@ NVSDK_NGX_API NVSDK_NGX_Result NVSDK_NGX_D3D12_EvaluateFeature(ID3D12GraphicsCom
         InParameters->Set("DLSSG.CameraFar", lastDlssgCameraFar.value());
 
     if (nrUpscale)
-        DlssNr::EvaluateBeforeUpscale(InCmdList, InParameters, nullptr, 0,
-                                      rayReconstruction);
+        DlssNr::EvaluateBeforeUpscale(InCmdList, InParameters, nullptr, 0, rayReconstruction);
 
     // OptiScaler internal handling
     const NVSDK_NGX_Result optiResult = TryEvaluateOptiFeature(InCmdList, InFeatureHandle, InParameters, InCallback);
 
     // Same pass, for OptiScaler's own upscalers rather than native DLSS.
     if (optiResult == NVSDK_NGX_Result_Success && nrUpscale)
-        DlssNr::EvaluateAfterUpscale(InCmdList, InParameters, nullptr,
-                                     rayReconstruction);
+        DlssNr::EvaluateAfterUpscale(InCmdList, InParameters, nullptr, rayReconstruction);
 
     return optiResult;
 }

--- a/OptiScaler/inputs/NVNGX_DLSS_Dx12.cpp
+++ b/OptiScaler/inputs/NVNGX_DLSS_Dx12.cpp
@@ -3,6 +3,7 @@
 #include "Config.h"
 
 #include "NVNGX_DLSS.h"
+#include "NgxFeatureRegistry.h"
 #include "NVNGX_Parameter.h"
 #include "proxies/NVNGX_Proxy.h"
 #include "dlssnr/DlssNr.h"
@@ -28,7 +29,7 @@
 #include <misc/IdentifyGpu.h>
 
 static ankerl::unordered_dense::map<unsigned int, ContextData<IFeature_Dx12>> Dx12Contexts;
-static std::unordered_map<unsigned int, NVSDK_NGX_Feature> HandleToFeature;
+static NgxFeatureRegistry HandleToFeature;
 
 static ID3D12Device* D3D12Device = nullptr;
 static int evalCounter = 0;
@@ -766,10 +767,10 @@ NVSDK_NGX_API NVSDK_NGX_Result NVSDK_NGX_D3D12_CreateFeature(ID3D12GraphicsComma
 
         NVSDK_NGX_Result res = Nvngx_FG::D3D12_CreateFeature(InCmdList, InFeatureID, InParameters, OutHandle);
 
-        if (*OutHandle)
+        if (res == NVSDK_NGX_Result_Success && *OutHandle)
         {
             LOG_INFO("Created modded DLSSG feature with HandleId: {}", (*OutHandle)->Id);
-            HandleToFeature[(*OutHandle)->Id] = InFeatureID;
+            HandleToFeature.Record((*OutHandle)->Id, InFeatureID);
         }
 
         return res;
@@ -785,10 +786,10 @@ NVSDK_NGX_API NVSDK_NGX_Result NVSDK_NGX_D3D12_CreateFeature(ID3D12GraphicsComma
 
             NVSDK_NGX_Result res = NVNGXProxy::D3D12_CreateFeature()(InCmdList, InFeatureID, InParameters, OutHandle);
 
-            if (*OutHandle)
+            if (res == NVSDK_NGX_Result_Success && *OutHandle)
             {
                 LOG_INFO("Native CreateFeature success, HandleId: {}", (*OutHandle)->Id);
-                HandleToFeature[(*OutHandle)->Id] = InFeatureID;
+                HandleToFeature.Record((*OutHandle)->Id, InFeatureID);
             }
             else
             {
@@ -805,8 +806,8 @@ NVSDK_NGX_API NVSDK_NGX_Result NVSDK_NGX_D3D12_CreateFeature(ID3D12GraphicsComma
     // OptiScaler internal handling (SuperSampling or RayReconstruction)
     auto tryResult = TryCreateOptiFeature(InCmdList, InFeatureID, InParameters, OutHandle);
 
-    if (tryResult == NVSDK_NGX_Result_Success)
-        HandleToFeature[(*OutHandle)->Id] = InFeatureID;
+    if (tryResult == NVSDK_NGX_Result_Success && *OutHandle)
+        HandleToFeature.Record((*OutHandle)->Id, InFeatureID);
 
     return tryResult;
 }
@@ -853,6 +854,8 @@ NVSDK_NGX_API NVSDK_NGX_Result NVSDK_NGX_D3D12_ReleaseFeature(NVSDK_NGX_Handle* 
             if (!shutdown)
                 LOG_INFO("D3D12_ReleaseFeature result for ({0}): {1:X}", handleId, (UINT) result);
 
+            if (result == NVSDK_NGX_Result_Success)
+                HandleToFeature.Forget(handleId);
             return result;
         }
         else
@@ -867,7 +870,10 @@ NVSDK_NGX_API NVSDK_NGX_Result NVSDK_NGX_D3D12_ReleaseFeature(NVSDK_NGX_Handle* 
     else if (State::Instance().activeFgNvngx != FGNvngxReplacement::None && handleId >= NVNGX_PROVIDER_ID_OFFSET)
     {
         LOG_INFO("D3D12_ReleaseFeature modded DLSSG with HandleId: {0}", handleId);
-        return Nvngx_FG::D3D12_ReleaseFeature(InHandle);
+        const auto result = Nvngx_FG::D3D12_ReleaseFeature(InHandle);
+        if (result == NVSDK_NGX_Result_Success)
+            HandleToFeature.Forget(handleId);
+        return result;
     }
 
     // Remove feature from context map
@@ -892,6 +898,7 @@ NVSDK_NGX_API NVSDK_NGX_Result NVSDK_NGX_D3D12_ReleaseFeature(NVSDK_NGX_Handle* 
             LOG_ERROR("can't release feature with id {0}!", handleId);
     }
 
+    HandleToFeature.Forget(handleId);
     return NVSDK_NGX_Result_Success;
 }
 
@@ -1112,10 +1119,24 @@ NVSDK_NGX_API NVSDK_NGX_Result NVSDK_NGX_D3D12_EvaluateFeature(ID3D12GraphicsCom
     const State& state = State::Instance();
     const Config& cfg = *Config::Instance();
 
-    auto feature = HandleToFeature[handleId];
+    const auto tracked = HandleToFeature.Read(handleId);
+    const auto feature = tracked.feature;
+    bool nrUpscale = feature == NVSDK_NGX_Feature_SuperSampling ||
+                     feature == NVSDK_NGX_Feature_RayReconstruction;
+    bool rayReconstruction = feature == NVSDK_NGX_Feature_RayReconstruction;
+    // A live OptiScaler backend is additional evidence, especially if the
+    // creation record is absent or an SR handle has switched to DLSSD.
+    if (auto it = Dx12Contexts.find(handleId); it != Dx12Contexts.end() && it->second.feature)
+    {
+        nrUpscale = true;
+        rayReconstruction |= it->second.feature->GetUpscalerType() == Upscaler::DLSSD;
+    }
+    if (!tracked.feature && !nrUpscale)
+        LOG_DEBUG("DLSS-NR: skipping untracked NGX handle {}; original evaluate is preserved", handleId);
+    LOG_DEBUG("DLSS-NR route: handle {}, NGX feature {}, upscaler {}, RR {}", handleId,
+              tracked.feature ? (int) *tracked.feature : -1, nrUpscale, rayReconstruction);
     static size_t evalWithoutFG = 0;
-    bool fgCreated = std::any_of(HandleToFeature.begin(), HandleToFeature.end(),
-                                 [](const auto& pair) { return pair.second == NVSDK_NGX_Feature_FrameGeneration; });
+    const bool fgCreated = tracked.frameGenerationCreated;
 
     static std::optional<float> lastDlssgCameraNear {};
     static std::optional<float> lastDlssgCameraFar {};
@@ -1157,9 +1178,9 @@ NVSDK_NGX_API NVSDK_NGX_Result NVSDK_NGX_D3D12_EvaluateFeature(ID3D12GraphicsCom
         {
             LOG_DEBUG("Passthrough to native DLSS EvaluateFeature for handle {}", handleId);
 
-            if (feature == NVSDK_NGX_Feature_SuperSampling || feature == NVSDK_NGX_Feature_RayReconstruction)
+            if (nrUpscale)
                 DlssNr::EvaluateBeforeUpscale(InCmdList, InParameters, nullptr, 0,
-                                              feature == NVSDK_NGX_Feature_RayReconstruction);
+                                              rayReconstruction);
 
             NVSDK_NGX_Result result =
                 NVNGXProxy::D3D12_EvaluateFeature()(InCmdList, InFeatureHandle, InParameters, InCallback);
@@ -1170,9 +1191,9 @@ NVSDK_NGX_API NVSDK_NGX_Result NVSDK_NGX_D3D12_EvaluateFeature(ID3D12GraphicsCom
             // rendered frame. The feature check is the point: frame generation is handed depth and
             // motion vectors too, and its handle can reach here because the branch above does not
             // return, so filtering on the parameter block alone would run the model twice a frame.
-            if (result == NVSDK_NGX_Result_Success && feature != NVSDK_NGX_Feature_FrameGeneration)
+            if (result == NVSDK_NGX_Result_Success && nrUpscale)
                 DlssNr::EvaluateAfterUpscale(InCmdList, InParameters, nullptr,
-                                             feature == NVSDK_NGX_Feature_RayReconstruction);
+                                             rayReconstruction);
 
             return result;
         }
@@ -1194,17 +1215,17 @@ NVSDK_NGX_API NVSDK_NGX_Result NVSDK_NGX_D3D12_EvaluateFeature(ID3D12GraphicsCom
     if (lastDlssgCameraFar.has_value())
         InParameters->Set("DLSSG.CameraFar", lastDlssgCameraFar.value());
 
-    if (feature == NVSDK_NGX_Feature_SuperSampling || feature == NVSDK_NGX_Feature_RayReconstruction)
+    if (nrUpscale)
         DlssNr::EvaluateBeforeUpscale(InCmdList, InParameters, nullptr, 0,
-                                      feature == NVSDK_NGX_Feature_RayReconstruction);
+                                      rayReconstruction);
 
     // OptiScaler internal handling
     const NVSDK_NGX_Result optiResult = TryEvaluateOptiFeature(InCmdList, InFeatureHandle, InParameters, InCallback);
 
     // Same pass, for OptiScaler's own upscalers rather than native DLSS.
-    if (optiResult == NVSDK_NGX_Result_Success && feature != NVSDK_NGX_Feature_FrameGeneration)
+    if (optiResult == NVSDK_NGX_Result_Success && nrUpscale)
         DlssNr::EvaluateAfterUpscale(InCmdList, InParameters, nullptr,
-                                     feature == NVSDK_NGX_Feature_RayReconstruction);
+                                     rayReconstruction);
 
     return optiResult;
 }

--- a/OptiScaler/inputs/NgxFeatureRegistry.h
+++ b/OptiScaler/inputs/NgxFeatureRegistry.h
@@ -1,0 +1,42 @@
+#pragma once
+
+#include <nvsdk_ngx_defs.h>
+#include <mutex>
+#include <optional>
+#include <unordered_map>
+
+class NgxFeatureRegistry
+{
+    std::mutex mutex;
+    std::unordered_map<unsigned int, NVSDK_NGX_Feature> features;
+
+  public:
+    void Record(unsigned int handle, NVSDK_NGX_Feature feature)
+    {
+        std::lock_guard lock(mutex);
+        features[handle] = feature;
+    }
+
+    void Forget(unsigned int handle)
+    {
+        std::lock_guard lock(mutex);
+        features.erase(handle);
+    }
+
+    struct Snapshot
+    {
+        std::optional<NVSDK_NGX_Feature> feature;
+        bool frameGenerationCreated = false;
+    };
+
+    Snapshot Read(unsigned int handle)
+    {
+        std::lock_guard lock(mutex);
+        Snapshot result;
+        if (auto it = features.find(handle); it != features.end())
+            result.feature = it->second;
+        for (const auto& [id, feature] : features)
+            result.frameGenerationCreated |= feature == NVSDK_NGX_Feature_FrameGeneration;
+        return result;
+    }
+};

--- a/OptiScaler/shaders/dlssnr/DlssNr_Dx12.cpp
+++ b/OptiScaler/shaders/dlssnr/DlssNr_Dx12.cpp
@@ -2900,7 +2900,11 @@ void EvaluateInternal(ID3D12GraphicsCommandList* cmdList, NVSDK_NGX_Parameter* p
     }
     DlssNrNative::SetPrecision(precision);
     if (!cfg.DlssNrEnabled.value_or_default() || !cfg.DlssNrDeferredDlss.value_or_default() || rayReconstruction)
+    {
         DeferredSr::Cancel();
+        if (rayReconstruction && cfg.DlssNrEnabled.value_or_default() && cfg.DlssNrDeferredDlss.value_or_default())
+            DeferredSr::Say("inactive: Ray Reconstruction; using ordinary before/after NR placement");
+    }
     else
     {
         if (cmdList != nullptr && params != nullptr)

--- a/OptiScaler/upscalers/IFeature_Dx11wDx12.cpp
+++ b/OptiScaler/upscalers/IFeature_Dx11wDx12.cpp
@@ -364,8 +364,7 @@ bool IFeature_Dx11wDx12::Evaluate(ID3D11DeviceContext* InDeviceContext, NVSDK_NG
     const bool hasRestoreParamDepth =
         getOriginalNgxResource(InParameters, NVSDK_NGX_Parameter_Depth, &restoreParamDepth);
     getOriginalNgxResource(InParameters, NVSDK_NGX_Parameter_ExposureTexture, &restoreParamExposure);
-    getOriginalNgxResource(
-        InParameters, NVSDK_NGX_Parameter_DLSS_Input_Bias_Current_Color_Mask, &restoreParamReactive);
+    getOriginalNgxResource(InParameters, NVSDK_NGX_Parameter_DLSS_Input_Bias_Current_Color_Mask, &restoreParamReactive);
 
     ID3D11ShaderResourceView* restoreSRVs[D3D11_COMMONSHADER_INPUT_RESOURCE_SLOT_COUNT] = {};
     ID3D11SamplerState* restoreSamplerStates[D3D11_COMMONSHADER_SAMPLER_SLOT_COUNT] = {};
@@ -449,8 +448,8 @@ bool IFeature_Dx11wDx12::Evaluate(ID3D11DeviceContext* InDeviceContext, NVSDK_NG
         InParameters->Set(NVSDK_NGX_Parameter_Output, (void*) dx11Out.Dx12Resource);
         InParameters->Set(NVSDK_NGX_Parameter_Depth, (void*) dx11Depth.Dx12Resource);
 
-        SetOptionalDx12Inputs(InParameters, dx11Exp.Dx12Resource, dx11Reactive.Dx12Resource,
-                              AutoExposure(), Config::Instance()->DisableReactiveMask.value_or(false));
+        SetOptionalDx12Inputs(InParameters, dx11Exp.Dx12Resource, dx11Reactive.Dx12Resource, AutoExposure(),
+                              Config::Instance()->DisableReactiveMask.value_or(false));
 
         LOG_DEBUG("Dispatch!!");
         DlssNr::EvaluateBeforeUpscale(cmdList, InParameters, Dx12CommandQueue, _frameCount,

--- a/OptiScaler/upscalers/IFeature_Dx11wDx12.cpp
+++ b/OptiScaler/upscalers/IFeature_Dx11wDx12.cpp
@@ -1,5 +1,6 @@
 #include <pch.h>
 #include "IFeature_Dx11wDx12.h"
+#include "NgxOptionalDx12Inputs.h"
 
 #include <dlssnr/DlssNr.h>
 
@@ -362,9 +363,8 @@ bool IFeature_Dx11wDx12::Evaluate(ID3D11DeviceContext* InDeviceContext, NVSDK_NG
         getOriginalNgxResource(InParameters, NVSDK_NGX_Parameter_Output, &restoreParamOutput);
     const bool hasRestoreParamDepth =
         getOriginalNgxResource(InParameters, NVSDK_NGX_Parameter_Depth, &restoreParamDepth);
-    const bool hasRestoreParamExposure =
-        getOriginalNgxResource(InParameters, NVSDK_NGX_Parameter_ExposureTexture, &restoreParamExposure);
-    const bool hasRestoreParamReactive = getOriginalNgxResource(
+    getOriginalNgxResource(InParameters, NVSDK_NGX_Parameter_ExposureTexture, &restoreParamExposure);
+    getOriginalNgxResource(
         InParameters, NVSDK_NGX_Parameter_DLSS_Input_Bias_Current_Color_Mask, &restoreParamReactive);
 
     ID3D11ShaderResourceView* restoreSRVs[D3D11_COMMONSHADER_INPUT_RESOURCE_SLOT_COUNT] = {};
@@ -449,12 +449,8 @@ bool IFeature_Dx11wDx12::Evaluate(ID3D11DeviceContext* InDeviceContext, NVSDK_NG
         InParameters->Set(NVSDK_NGX_Parameter_Output, (void*) dx11Out.Dx12Resource);
         InParameters->Set(NVSDK_NGX_Parameter_Depth, (void*) dx11Depth.Dx12Resource);
 
-        if (!AutoExposure() && dx11Exp.Dx12Resource != nullptr)
-            InParameters->Set(NVSDK_NGX_Parameter_ExposureTexture, (void*) dx11Exp.Dx12Resource);
-
-        if (!Config::Instance()->DisableReactiveMask.value_or(false) && dx11Reactive.Dx12Resource != nullptr)
-            InParameters->Set(NVSDK_NGX_Parameter_DLSS_Input_Bias_Current_Color_Mask,
-                              (void*) dx11Reactive.Dx12Resource);
+        SetOptionalDx12Inputs(InParameters, dx11Exp.Dx12Resource, dx11Reactive.Dx12Resource,
+                              AutoExposure(), Config::Instance()->DisableReactiveMask.value_or(false));
 
         LOG_DEBUG("Dispatch!!");
         DlssNr::EvaluateBeforeUpscale(cmdList, InParameters, Dx12CommandQueue, _frameCount,
@@ -502,11 +498,9 @@ bool IFeature_Dx11wDx12::Evaluate(ID3D11DeviceContext* InDeviceContext, NVSDK_NG
     if (hasRestoreParamDepth)
         InParameters->Set(NVSDK_NGX_Parameter_Depth, (void*) restoreParamDepth);
 
-    if (hasRestoreParamExposure)
-        InParameters->Set(NVSDK_NGX_Parameter_ExposureTexture, (void*) restoreParamExposure);
-
-    if (hasRestoreParamReactive)
-        InParameters->Set(NVSDK_NGX_Parameter_DLSS_Input_Bias_Current_Color_Mask, (void*) restoreParamReactive);
+    // Restore nulls too: no D3D12 pointer may escape back into the DX11 caller.
+    InParameters->Set(NVSDK_NGX_Parameter_ExposureTexture, (void*) restoreParamExposure);
+    InParameters->Set(NVSDK_NGX_Parameter_DLSS_Input_Bias_Current_Color_Mask, (void*) restoreParamReactive);
 
     if (commandListRecording)
     {

--- a/OptiScaler/upscalers/IFeature_VkwDx12.cpp
+++ b/OptiScaler/upscalers/IFeature_VkwDx12.cpp
@@ -2150,8 +2150,8 @@ bool IFeature_VkwDx12::Evaluate(VkCommandBuffer InCmdBuffer, NVSDK_NGX_Parameter
         InParameters->Set(NVSDK_NGX_Parameter_Output, (void*) vkOut.Dx12Resource);
         InParameters->Set(NVSDK_NGX_Parameter_Depth, (void*) vkDepth.Dx12Resource);
 
-        SetOptionalDx12Inputs(InParameters, vkExp.Dx12Resource, vkReactive.Dx12Resource,
-                              AutoExposure(), Config::Instance()->DisableReactiveMask.value_or(false));
+        SetOptionalDx12Inputs(InParameters, vkExp.Dx12Resource, vkReactive.Dx12Resource, AutoExposure(),
+                              Config::Instance()->DisableReactiveMask.value_or(false));
 
         LOG_DEBUG("Dispatch!!");
         DlssNr::EvaluateBeforeUpscale(cmdList, InParameters, Dx12CommandQueue, _frameCount,

--- a/OptiScaler/upscalers/IFeature_VkwDx12.cpp
+++ b/OptiScaler/upscalers/IFeature_VkwDx12.cpp
@@ -1,6 +1,7 @@
 #include <pch.h>
 
 #include "IFeature_VkwDx12.h"
+#include "NgxOptionalDx12Inputs.h"
 
 #include <Config.h>
 #include <dlssnr/DlssNr.h>
@@ -2149,11 +2150,8 @@ bool IFeature_VkwDx12::Evaluate(VkCommandBuffer InCmdBuffer, NVSDK_NGX_Parameter
         InParameters->Set(NVSDK_NGX_Parameter_Output, (void*) vkOut.Dx12Resource);
         InParameters->Set(NVSDK_NGX_Parameter_Depth, (void*) vkDepth.Dx12Resource);
 
-        if (!AutoExposure() && vkExp.Dx12Resource != nullptr)
-            InParameters->Set(NVSDK_NGX_Parameter_ExposureTexture, (void*) vkExp.Dx12Resource);
-
-        if (!Config::Instance()->DisableReactiveMask.value_or(false) && vkReactive.Dx12Resource != nullptr)
-            InParameters->Set(NVSDK_NGX_Parameter_DLSS_Input_Bias_Current_Color_Mask, (void*) vkReactive.Dx12Resource);
+        SetOptionalDx12Inputs(InParameters, vkExp.Dx12Resource, vkReactive.Dx12Resource,
+                              AutoExposure(), Config::Instance()->DisableReactiveMask.value_or(false));
 
         LOG_DEBUG("Dispatch!!");
         DlssNr::EvaluateBeforeUpscale(cmdList, InParameters, Dx12CommandQueue, _frameCount,

--- a/OptiScaler/upscalers/NgxOptionalDx12Inputs.h
+++ b/OptiScaler/upscalers/NgxOptionalDx12Inputs.h
@@ -7,11 +7,10 @@ struct ID3D12Resource;
 // The caller's parameter block may still contain DX11/Vulkan pointers. Even an
 // unused optional input must be replaced before any D3D12 consumer sees it.
 template <typename Parameters>
-void SetOptionalDx12Inputs(Parameters* parameters, ID3D12Resource* exposure,
-                          ID3D12Resource* reactive, bool autoExposure, bool disableReactive)
+void SetOptionalDx12Inputs(Parameters* parameters, ID3D12Resource* exposure, ID3D12Resource* reactive,
+                           bool autoExposure, bool disableReactive)
 {
-    parameters->Set(NVSDK_NGX_Parameter_ExposureTexture,
-                    static_cast<void*>(autoExposure ? nullptr : exposure));
+    parameters->Set(NVSDK_NGX_Parameter_ExposureTexture, static_cast<void*>(autoExposure ? nullptr : exposure));
     parameters->Set(NVSDK_NGX_Parameter_DLSS_Input_Bias_Current_Color_Mask,
                     static_cast<void*>(disableReactive ? nullptr : reactive));
 }

--- a/OptiScaler/upscalers/NgxOptionalDx12Inputs.h
+++ b/OptiScaler/upscalers/NgxOptionalDx12Inputs.h
@@ -1,0 +1,17 @@
+#pragma once
+
+#include <nvsdk_ngx_defs.h>
+
+struct ID3D12Resource;
+
+// The caller's parameter block may still contain DX11/Vulkan pointers. Even an
+// unused optional input must be replaced before any D3D12 consumer sees it.
+template <typename Parameters>
+void SetOptionalDx12Inputs(Parameters* parameters, ID3D12Resource* exposure,
+                          ID3D12Resource* reactive, bool autoExposure, bool disableReactive)
+{
+    parameters->Set(NVSDK_NGX_Parameter_ExposureTexture,
+                    static_cast<void*>(autoExposure ? nullptr : exposure));
+    parameters->Set(NVSDK_NGX_Parameter_DLSS_Input_Bias_Current_Color_Mask,
+                    static_cast<void*>(disableReactive ? nullptr : reactive));
+}

--- a/docs/ISSUE-REVIEW-2026-09-10.md
+++ b/docs/ISSUE-REVIEW-2026-09-10.md
@@ -1,0 +1,45 @@
+# Open issue review — 10 September 2026
+
+Reviewed all ten open issues and their comments against `v0.7.5-nr-fixes` (`73f26daa`). Downloaded and read the Nioh 2 log, the Stellar Blade log archive, the updated standalone source contribution and the MFG implementation linked in #12. Reporter attachments were inspected as data/source, not executed.
+
+| Issue | Finding and disposition |
+| --- | --- |
+| [#3](https://github.com/wilsjo2/OptiScaler-DLSSNR-PreSR-Multipass/issues/3) Aphelion HDR/purple halos | Reporter explicitly confirms v0.7.3 completely fixed it. Closed as resolved. |
+| [#5](https://github.com/wilsjo2/OptiScaler-DLSSNR-PreSR-Multipass/issues/5) RR/upstream/async suggestions | Before/after RR placement and common controls shipped in v0.7.4. Kept open for a concrete remaining comparison/reproduction; no unsupported claim that another fork is universally better or that arbitrary async processing is safe. |
+| [#6](https://github.com/wilsjo2/OptiScaler-DLSSNR-PreSR-Multipass/issues/6) Standalone NR contribution | Reviewed the September 8 source update. Kept as an enhancement requiring integration, rather than replacing newer production files with its v0.6.2-era versions. See integration findings below. |
+| [#7](https://github.com/wilsjo2/OptiScaler-DLSSNR-PreSR-Multipass/issues/7) Requiem/Onimusha/Cyberpunk NR inactive | No reporter logs identify the failed stage. Hardened NGX routing and added diagnostics; requested per-game startup/reproduction logs, INI and placement details. Kept open. |
+| [#9](https://github.com/wilsjo2/OptiScaler-DLSSNR-PreSR-Multipass/issues/9) Deferred flashing | Per-evaluate seam fix shipped in v0.7.5 through #11. Existing seam regression passes. Closed the dropout/flash report; separate fine-detail shimmer is not claimed fixed. |
+| [#10](https://github.com/wilsjo2/OptiScaler-DLSSNR-PreSR-Multipass/issues/10) RR flicker | v0.7.3 guide fix predates current release; the older reports do not establish which problem remains. Added RR/deferred placement explanation and routing hardening. Requested a repeatable scene/settings and current evidence; kept open pending visual reproduction. |
+| [#12](https://github.com/wilsjo2/OptiScaler-DLSSNR-PreSR-Multipass/issues/12) RTX 40 MFG plus NR | Log shows the built-in patch applied but does not prove correct MFG output. Two users report external/alternate unlockers work. Provided the existing external-FG mode and requested paired logs if needed. No RTX 40 hardware available here; kept open. |
+| [#14](https://github.com/wilsjo2/OptiScaler-DLSSNR-PreSR-Multipass/issues/14) Before-RR option | Already implemented in v0.7.4 and present in v0.7.5. Closed the feature request, with failures tracked in #7/#10. Fixed the additional deferred-mode checkbox conflict discovered during review. |
+| [#15](https://github.com/wilsjo2/OptiScaler-DLSSNR-PreSR-Multipass/issues/15) Reflex 2 | Kept as an enhancement. DLL availability does not supply a general late-camera-pose integration. Requested source/interface documentation; no demo binaries incorporated. |
+| [#16](https://github.com/wilsjo2/OptiScaler-DLSSNR-PreSR-Multipass/issues/16) Nioh 2 crash | Identified a foreign-API optional-resource pointer escaping into DX12 NR. Fixed DX11 and Vulkan bridge handoffs. The crash log ends at the first exposure-processing stage with auto-exposure enabled, consistent with this defect. Kept open for reporter validation. |
+
+## Changes
+
+- Optional exposure/reactive resources are always overwritten with their DX12 resource or null before the bridge invokes a DX12 consumer. Auto-exposure and disabled-reactive paths previously retained the game's DX11/Vulkan pointer. DX11 restores the original optional values, including null, afterward.
+- The NGX handle registry uses a checked lookup, synchronizes its own reads/writes, records only successful creations and forgets successful releases. Unknown native handles and known non-upscaler features skip both NR seams while retaining the original NGX evaluation.
+- Live OptiScaler backend information supplements creation metadata for RR classification. A DLSSD backend excludes the SR-only deferred experiment even when the original record says SR. Debug logs include handle, creation feature ID, upscaler classification and RR classification.
+- A stored deferred-mode setting no longer disables the ordinary before/after placement control while the live backend is RR. The overlay and runtime status explain that RR uses ordinary placement.
+
+These changes do not establish the cause of every reported crash, flicker or lack of effect. They do not transform RR's auxiliary lighting/material inputs alongside colour.
+
+## Standalone contribution integration findings
+
+The newer attachment includes GPU-fence transport, settings tests and native-input handoff; the original performance/multipass limitations cannot simply be repeated as if the update did not exist. However:
+
+1. Its replacement `DlssNr_Dx12.cpp` still contains the old forced-post RR/`ApplyAfterRR` implementation. Copying it wholesale would undo the current unified before-RR path and newer synchronization changes.
+2. Current `EvaluateInternal` holds `g_nrMutex`. Adding the contribution's `PreferNativeInputs` call at the old location would acquire `ownerMutex` while holding `g_nrMutex`, whereas standalone Present holds `ownerMutex` while dispatch acquires `g_nrMutex`. Integration must avoid this lock-order inversion.
+3. On a failed GPU wait in the contribution's `StandaloneNR` destructor, the catch releases ownership of `impl` but returns without clearing global `owner`. A subsequent native handoff dereferences `owner->impl`, although that owner object has been destroyed. Quarantine the failed standalone path and clear the owner before accepting a later handoff.
+4. Dummy depth/zero motion and processing the final HUD are inherent limitations of this contribution's generic path. Its supplied test claims are not new verification on current main.
+
+The contribution remains open for a rebased integration with native handoff/timeout/resize tests. No standalone code is included in this patch.
+
+## Validation
+
+- Release x64 build passed. Existing C4744 and LNK4098 link warnings remain.
+- `tests/nr_ngx_routing_smoke.cpp`: missing/reused/released handles, removal of stale FG presence, concurrent registry reads/writes, and all eight combinations of optional-resource availability/auto-exposure/reactive disable passed. This is a CPU parameter-routing regression, not an NVIDIA model test.
+- `tests/nr_seam_clock_smoke.cpp`: pairing, Present-counter stalls/changes, gaps, resets and bridge epochs passed.
+- `git diff --check` passed.
+
+Cyberpunk is installed locally, but the existing local log is from v0.7.3 and does not show RR. No fresh gameplay or visual-quality validation was performed in this session. Nioh 2, Requiem, Onimusha, Stellar Blade, Aphelion, NBA 2K26, Dawnwalker and Crimson Desert were not found in the inspected Steam libraries. The available GPU is an RTX 5090, so RTX 40 MFG results need reporter testing.

--- a/docs/ISSUE-REVIEW-2026-09-10.md
+++ b/docs/ISSUE-REVIEW-2026-09-10.md
@@ -41,5 +41,6 @@ The contribution remains open for a rebased integration with native handoff/time
 - `tests/nr_ngx_routing_smoke.cpp`: missing/reused/released handles, removal of stale FG presence, concurrent registry reads/writes, and all eight combinations of optional-resource availability/auto-exposure/reactive disable passed. This is a CPU parameter-routing regression, not an NVIDIA model test.
 - `tests/nr_seam_clock_smoke.cpp`: pairing, Present-counter stalls/changes, gaps, resets and bridge epochs passed.
 - `git diff --check` passed.
+- GitHub's repository-wide clang-format check fails on existing main (`73f26daa`, [run](https://github.com/wilsjo2/OptiScaler-DLSSNR-PreSR-Multipass/actions/runs/34319077007)) as well as this branch. Applied formatting to the changed C++ ranges; unrelated repository-wide formatting remains outside this patch.
 
 Cyberpunk is installed locally, but the existing local log is from v0.7.3 and does not show RR. No fresh gameplay or visual-quality validation was performed in this session. Nioh 2, Requiem, Onimusha, Stellar Blade, Aphelion, NBA 2K26, Dawnwalker and Crimson Desert were not found in the inspected Steam libraries. The available GPU is an RTX 5090, so RTX 40 MFG results need reporter testing.

--- a/tests/nr_ngx_routing_smoke.cpp
+++ b/tests/nr_ngx_routing_smoke.cpp
@@ -25,13 +25,15 @@ int main()
     assert(!registry.Read(100).feature);
     registry.Record(100, NVSDK_NGX_Feature_SuperSampling);
     assert(registry.Read(100).feature == NVSDK_NGX_Feature_SuperSampling);
-    std::thread writer([&] {
-        for (unsigned int i = 0; i < 1000; ++i)
+    std::thread writer(
+        [&]
         {
-            registry.Record(200, NVSDK_NGX_Feature_FrameGeneration);
-            registry.Forget(200);
-        }
-    });
+            for (unsigned int i = 0; i < 1000; ++i)
+            {
+                registry.Record(200, NVSDK_NGX_Feature_FrameGeneration);
+                registry.Forget(200);
+            }
+        });
     for (unsigned int i = 0; i < 1000; ++i)
         assert(registry.Read(100).feature == NVSDK_NGX_Feature_SuperSampling);
     writer.join();
@@ -46,10 +48,9 @@ int main()
                 Parameters parameters;
                 parameters.Set(NVSDK_NGX_Parameter_ExposureTexture, &foreignExposure);
                 parameters.Set(NVSDK_NGX_Parameter_DLSS_Input_Bias_Current_Color_Mask, &foreignReactive);
-                SetOptionalDx12Inputs(&parameters,
-                    available ? reinterpret_cast<ID3D12Resource*>(&dx12Exposure) : nullptr,
-                    available ? reinterpret_cast<ID3D12Resource*>(&dx12Reactive) : nullptr,
-                    automatic, disabled);
+                SetOptionalDx12Inputs(
+                    &parameters, available ? reinterpret_cast<ID3D12Resource*>(&dx12Exposure) : nullptr,
+                    available ? reinterpret_cast<ID3D12Resource*>(&dx12Reactive) : nullptr, automatic, disabled);
                 assert(parameters.resources[NVSDK_NGX_Parameter_ExposureTexture] ==
                        (automatic || !available ? nullptr : &dx12Exposure));
                 assert(parameters.resources[NVSDK_NGX_Parameter_DLSS_Input_Bias_Current_Color_Mask] ==

--- a/tests/nr_ngx_routing_smoke.cpp
+++ b/tests/nr_ngx_routing_smoke.cpp
@@ -1,0 +1,59 @@
+#include "../OptiScaler/inputs/NgxFeatureRegistry.h"
+#include "../OptiScaler/upscalers/NgxOptionalDx12Inputs.h"
+#include <cassert>
+#include <iostream>
+#include <string>
+#include <thread>
+
+struct Parameters
+{
+    std::unordered_map<std::string, void*> resources;
+    void Set(const char* key, void* resource) { resources[key] = resource; }
+};
+
+int main()
+{
+    NgxFeatureRegistry registry;
+    assert(!registry.Read(100).feature);
+    registry.Record(100, NVSDK_NGX_Feature_RayReconstruction);
+    registry.Record(200, NVSDK_NGX_Feature_FrameGeneration);
+    assert(registry.Read(100).feature == NVSDK_NGX_Feature_RayReconstruction);
+    assert(registry.Read(100).frameGenerationCreated);
+    registry.Forget(200);
+    assert(!registry.Read(100).frameGenerationCreated);
+    registry.Forget(100);
+    assert(!registry.Read(100).feature);
+    registry.Record(100, NVSDK_NGX_Feature_SuperSampling);
+    assert(registry.Read(100).feature == NVSDK_NGX_Feature_SuperSampling);
+    std::thread writer([&] {
+        for (unsigned int i = 0; i < 1000; ++i)
+        {
+            registry.Record(200, NVSDK_NGX_Feature_FrameGeneration);
+            registry.Forget(200);
+        }
+    });
+    for (unsigned int i = 0; i < 1000; ++i)
+        assert(registry.Read(100).feature == NVSDK_NGX_Feature_SuperSampling);
+    writer.join();
+    assert(!registry.Read(100).frameGenerationCreated);
+
+    // Foreign-API sentinels must never survive an optional-input handoff.
+    int foreignExposure, foreignReactive, dx12Exposure, dx12Reactive;
+    for (bool automatic : { false, true })
+        for (bool disabled : { false, true })
+            for (bool available : { false, true })
+            {
+                Parameters parameters;
+                parameters.Set(NVSDK_NGX_Parameter_ExposureTexture, &foreignExposure);
+                parameters.Set(NVSDK_NGX_Parameter_DLSS_Input_Bias_Current_Color_Mask, &foreignReactive);
+                SetOptionalDx12Inputs(&parameters,
+                    available ? reinterpret_cast<ID3D12Resource*>(&dx12Exposure) : nullptr,
+                    available ? reinterpret_cast<ID3D12Resource*>(&dx12Reactive) : nullptr,
+                    automatic, disabled);
+                assert(parameters.resources[NVSDK_NGX_Parameter_ExposureTexture] ==
+                       (automatic || !available ? nullptr : &dx12Exposure));
+                assert(parameters.resources[NVSDK_NGX_Parameter_DLSS_Input_Bias_Current_Color_Mask] ==
+                       (disabled || !available ? nullptr : &dx12Reactive));
+            }
+    std::cout << "NGX handle lifecycle and 8 optional bridge input cases passed\n";
+}


### PR DESCRIPTION
NR could receive a DX11/Vulkan exposure pointer through a D3D12 bridge when auto-exposure left that optional input untranslated. Nioh 2's #16 log reaches the first exposure-processing stage before the reported D3D12Core access violation. Both bridges now supply a D3D12 optional resource or null, and DX11 restores the caller's optional values afterward.

NGX feature tracking now uses checked, synchronized lookups and removes released handles. Only identified upscalers enter NR; live DLSSD backend identity also blocks the SR-only deferred mode. While RR is active, a saved deferred setting no longer disables ordinary before/after placement, and the overlay/log explain the fallback.

Related: #7, #10, #12, #14, #16. These are targeted fixes and diagnostics, not confirmation that every reported game symptom is resolved. Keep #16 open pending reporter testing. No runtime/model binaries changed.

Validation: Release x64 build passed; CPU regressions cover NGX handle lifecycle/concurrent access and eight optional bridge-input cases; the existing deferred seam sequence regression passed; `git diff --check` passed. Existing C4744/LNK4098 link warnings remain. No new gameplay/visual-quality test or RTX 40 MFG validation was performed.

CI: the repository-wide clang-format check also fails on the unchanged main commit ([baseline run](https://github.com/wilsjo2/OptiScaler-DLSSNR-PreSR-Multipass/actions/runs/34319077007)). Formatted this patch's changed C++ ranges without reformatting unrelated files.

[The issue review](docs/ISSUE-REVIEW-2026-09-10.md) records the disposition of all ten open issues, including already-shipped fixes and integration findings for the standalone/Reflex proposals.
